### PR TITLE
Also install jsonnet

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -39,3 +39,6 @@ unzip master.zip
 
 cd flask_gunicorn_nginx_docker-master
 bash run_docker.sh
+
+# also, install jsonnet. This is required for compiling jsonnet files to yaml so that things can be built and published.
+sudo snap install jsonnet


### PR DESCRIPTION
Add jsonnet.  This is so that when we fetch our functions.zip from S3, that when we unzip it we can format the jsonnet file to yaml, taking variables app_id and docker_account_name, and then build to {{docker_account_name}}/{{app_id}}{{function_name}}, prior to publishing the built image to the OpenFaaS server